### PR TITLE
Fix/standard rem units

### DIFF
--- a/src/components/ChevronRight.js
+++ b/src/components/ChevronRight.js
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export const ChevronRight = props => (
+  <svg
+    style={{
+      display: 'intline-block',
+      marginBottom: '-4px',
+      marginLeft: '6px',
+    }}
+    width={11}
+    height={18}
+    viewBox="0 0 11 18"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M2 2l7 7-7 7"
+      stroke="#2D2F7F"
+      strokeWidth={3}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)

--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-size: 62.5%;
+  font-size: 16px;
 }
 
 html {
@@ -19,25 +19,26 @@ body {
   margin: 0;
   font-family: 'Roboto', sans-serif;
   color: #000000; 
-  font-size: 1.8rem;
+  font-size: 1.125rem;
   line-height: 1.25;
   background-color: #EFEFEF;
 }
 
 h1 {
-  font-size: 3.2rem;
+  font-size: 2rem;
   line-height: 1.2;
   font-family: 'Poppins', sans-serif;
   text-rendering: optimizeLegibility;
-  margin: 0 0 3rem 0;
+  margin: 0 0 1.875rem 0;
 }
 
 h2 {
-  font-size: 2.4rem;
+  font-size: 1.5rem;
   line-height: 1.2222;
+  font-weight: 600;
   font-family: 'Poppins', sans-serif;
   text-rendering: optimizeLegibility;
-  margin: 0 0 3rem 0;
+  margin: 0 0 1.875rem 0;
 }
 
 h3 {
@@ -45,13 +46,17 @@ h3 {
   line-height: 1.25;
   font-family: 'Poppins', sans-serif;
   text-rendering: optimizeLegibility;
-  margin: 0 0 2rem 0;
+  margin: 0 0 1.25rem 0;
+}
+
+h1, h2, h3 {
+  color: #2d2f7f;
 }
 
 p {
-  font-size: 1.8rem;
-  line-height: 1.25;
-  margin: 0 0 2rem 0;
+  font-size: 1.125rem;
+  line-height: 1.6;
+  margin: 0 0 1.25rem 0;
 }
 
 img {
@@ -62,12 +67,12 @@ img {
 /*Desktop Styles*/
 @media (min-width: 768px) {
   h1 {
-    font-size: 3.2rem;
+    font-size: 2rem;
     line-height: 1.1875;
   }
 
   h2 {
-    font-size: 2.4rem;
+    font-size: 1.5rem;
     line-height: 1.2083;
   }
 }

--- a/src/templates/Event.js
+++ b/src/templates/Event.js
@@ -73,6 +73,7 @@ const InfoPlaceholder = styled.div`
 export default class Event extends Component {
   render() {
     const {
+      id,
       individualEventPicture,
       eventDescription,
       name,
@@ -97,7 +98,7 @@ export default class Event extends Component {
         <ContentWrapper>
           <ReactMarkdown source={eventDescription.eventDescription} />
           <EventSchedule schedule={performances} />
-          <EventsYouMayLike eventId={this.state.event.id} />
+          <EventsYouMayLike eventId={id} />
         </ContentWrapper>
       </PageWrapper>
     )

--- a/src/templates/Event.js
+++ b/src/templates/Event.js
@@ -30,7 +30,7 @@ const ContentWrapper = styled.div`
   width: 100vw;
   ${media.desktop`
     padding: 0;
-    margin-left: 80px;
+    margin-left: 90px;
     max-width: 45vw;
   `};
   ${media.desktopHD`
@@ -70,6 +70,10 @@ const InfoPlaceholder = styled.div`
  `};
 `
 
+const Section = styled.div`
+  margin-bottom: 60px;
+`
+
 export default class Event extends Component {
   render() {
     const {
@@ -96,10 +100,14 @@ export default class Event extends Component {
         </HeroImageAndTitle>
         <InfoPlaceholder>put things inside me plz</InfoPlaceholder>
         <ContentWrapper>
-          <ReactMarkdown source={eventDescription.eventDescription} />
-          <EventSchedule schedule={performances} />
-          <EventsYouMayLike eventId={id} />
+          <Section>
+            <ReactMarkdown source={eventDescription.eventDescription} />
+          </Section>
+          <Section>
+            <EventSchedule schedule={performances} />
+          </Section>
         </ContentWrapper>
+        <EventsYouMayLike eventId={id} />
       </PageWrapper>
     )
   }

--- a/src/templates/events/EventListingCard.js
+++ b/src/templates/events/EventListingCard.js
@@ -35,8 +35,10 @@ const CardDate = styled.span`
   display: block;
   color: ${props => props.theme.colors.darkGrey};
   font-size: 0.875rem;
-  font-weight: bold;
-  margin-bottom: 0.625rem;
+  line-height: 1.43;
+  font-weight: 600;
+  margin-bottom: 0.65rem;
+  font-family: Poppins, sans-serif;
 `
 
 const CardPrice = styled.div`
@@ -49,6 +51,13 @@ const CardPrice = styled.div`
   font-weight: 600;
   padding: 5px 10px;
   border-radius: 5px;
+  font-size: 1rem;
+`
+
+const CardHeading = styled.h2`
+  margin-bottom: 0;
+  line-height: 1.21;
+  color: black;
 `
 
 export const EventListingCard = props => {
@@ -64,7 +73,7 @@ export const EventListingCard = props => {
       />
       <CardBody>
         <CardDate>{formatDate(event)}</CardDate>
-        <h2>{event.name}</h2>
+        <CardHeading>{event.name}</CardHeading>
       </CardBody>
       <CardPrice>from £{event.eventPriceLow}</CardPrice>
     </Card>

--- a/src/templates/events/EventSchedule.js
+++ b/src/templates/events/EventSchedule.js
@@ -26,7 +26,7 @@ const splitIntoArray = schedule =>
       morning: [],
       afternoon: [],
       evening: [],
-    },
+    }
   )
 
 const EventSchedule = props => {

--- a/src/templates/events/EventScheduleItem.js
+++ b/src/templates/events/EventScheduleItem.js
@@ -2,29 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-const fontStyles = `
-  font-size: 0.8em;
-  letter-spacing: 0.4px;
-  padding: 8px 12px
-`
-
-const ShowMore = styled.p`
-  border-bottom: 2px solid ${props => props.theme.colors.eucalyptusGreen};
-  color: ${props => props.theme.colors.indigo};
-  cursor: pointer;
-  font-size: 0.9em;
-  font-weight: 300;
-  letter-spacing: 0.4px;
-  margin: 15px auto;
-  user-select: none;
-  width: fit-content;
-`
-
-const ShowMoreWrapper = styled.div`
-  text-align: center;
-  width: 100%;
-`
-
 const Table = styled.table`
   text-align: left;
   width: 100%;
@@ -32,15 +9,16 @@ const Table = styled.table`
 `
 
 const TableHeader = styled.th`
-  ${fontStyles}
-  background: ${props => props.theme.colors.mediumGrey};
+  padding: 10px 20px;
+  font-size: 1rem;
+  background: ${props => props.theme.colors.lightGrey};
   color: ${props => props.theme.colors.indigo};
   font-family: ${props => props.theme.fonts.title};
   font-weight: 300;
 `
 
 const TableItem = styled.td`
-  ${fontStyles};
+  padding: 10px 20px;
   border-bottom: 1px solid ${props => props.theme.colors.mediumGrey};
 `
 
@@ -49,26 +27,24 @@ const TableItemTime = styled(TableItem)`
   width: 60px;
 `
 
-const EventScheduleItem = props => (
-  <div>
-    <Table>
-      <tbody>
-        <tr>
-          <TableHeader colSpan="2">{props.title}</TableHeader>
-        </tr>
-        {props.data.map(item => (
-          <tr key={item.id}>
-            <TableItemTime>{item.startTime}</TableItemTime>
-            <TableItem>{item.title}</TableItem>
+const EventScheduleItem = props =>
+  props.data.length ? (
+    <div>
+      <Table>
+        <tbody>
+          <tr>
+            <TableHeader colSpan="2">{props.title}</TableHeader>
           </tr>
-        ))}
-      </tbody>
-    </Table>
-    <ShowMoreWrapper>
-      <ShowMore>Show more</ShowMore>
-    </ShowMoreWrapper>
-  </div>
-)
+          {props.data.map(item => (
+            <tr key={item.id}>
+              <TableItemTime>{item.startTime}</TableItemTime>
+              <TableItem>{item.title}</TableItem>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  ) : null
 
 EventScheduleItem.propTypes = {
   data: PropTypes.array,

--- a/src/templates/events/EventScheduleItem.js
+++ b/src/templates/events/EventScheduleItem.js
@@ -28,6 +28,7 @@ const ShowMoreWrapper = styled.div`
 const Table = styled.table`
   text-align: left;
   width: 100%;
+  margin-bottom: 18px;
 `
 
 const TableHeader = styled.th`

--- a/src/templates/events/EventsYouMayLike.js
+++ b/src/templates/events/EventsYouMayLike.js
@@ -10,7 +10,7 @@ const ViewAll = styled.a`
   color: ${props => props.theme.colors.indigo};
   display: block;
   font-family: ${props => props.theme.fonts.title};
-  font-size: 0.8em;
+  font-size: 0.875rem;
   letter-spacing: 0.1px;
   padding-top: 5px;
   text-align: right;

--- a/src/templates/events/EventsYouMayLike.js
+++ b/src/templates/events/EventsYouMayLike.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import moment from 'moment'
 import EventListingCard from './EventListingCard'
+import { ChevronRight } from '../../components/ChevronRight'
 import { Consumer } from '../../components/AppContext'
 import { Container, Row, Column } from '../../components/grid/grid'
 
@@ -10,8 +11,7 @@ const ViewAll = styled.a`
   color: ${props => props.theme.colors.indigo};
   display: block;
   font-family: ${props => props.theme.fonts.title};
-  font-size: 0.875rem;
-  letter-spacing: 0.1px;
+  font-size: 1rem;
   padding-top: 5px;
   text-align: right;
   text-decoration: none;
@@ -32,6 +32,11 @@ const filterEventsYouMayLike = (events, eventId) => {
   return filteredEvents.splice(0, 3)
 }
 
+const StyledContainer = styled(Container)`
+  padding-top: 60px;
+  background-color: ${props => props.theme.colors.lightGrey};
+`
+
 const EventsYouMayLike = ({ eventId }) => (
   <Consumer>
     {({ events }) => {
@@ -40,13 +45,15 @@ const EventsYouMayLike = ({ eventId }) => (
       if (eventsYouMayLike.length === 0) return null
 
       return (
-        <Container>
+        <StyledContainer>
           <Row>
             <Column width={0.7}>
-              <h2>You may also like</h2>
+              <h1>You may also like</h1>
             </Column>
             <Column width={0.3}>
-              <ViewAll href="/events">View all events {'>'}</ViewAll>
+              <ViewAll href="/events">
+                View all events <ChevronRight />
+              </ViewAll>
             </Column>
           </Row>
           <Row>
@@ -56,7 +63,7 @@ const EventsYouMayLike = ({ eventId }) => (
               </FlexColumn>
             ))}
           </Row>
-        </Container>
+        </StyledContainer>
       )
     }}
   </Consumer>

--- a/src/templates/events/filters/EventDateFilter.js
+++ b/src/templates/events/filters/EventDateFilter.js
@@ -27,7 +27,7 @@ const DatePickerWrapper = styled.div`
       border: none;
       appearance: none;
       padding: 14px 20px;
-      font-size: 0.875em;
+      font-size: 0.875rem;
       line-height: 1.214;
       box-sizing: border-box;
       display: block;


### PR DESCRIPTION
⚠️ ❗️ This is based on pr #45 which should be reviewed and merged first

Yesterday I changed the `rem` units to be based at 62.5% since that means you can use `rem` as `px / 10` and then conversion from px in Zeplin is made super easy, you just divide by ten. That's fine if you're in charge of all the styles, but we're using a date picker component which uses normal `rem` as if it were based at 100%, and that made it very small indeed. So I've reverted the change and we'll need to be vigilant about converting px in Zeplin to rem accurately (You can use: https://www.ninjaunits.com/converters/pixels/pixels-rem/ — set the default pixel size to 16px).

A couple of other style fixes made their way into this PR