### PR TITLE
Fix some event page styling

### DIFF
--- a/src/components/ChevronRight.js
+++ b/src/components/ChevronRight.js
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export const ChevronRight = props => (
+  <svg
+    style={{
+      display: 'intline-block',
+      marginBottom: '-4px',
+      marginLeft: '6px',
+    }}
+    width={11}
+    height={18}
+    viewBox="0 0 11 18"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M2 2l7 7-7 7"
+      stroke="#2D2F7F"
+      strokeWidth={3}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)

--- a/src/templates/Event.js
+++ b/src/templates/Event.js
@@ -30,7 +30,7 @@ const ContentWrapper = styled.div`
   width: 100vw;
   ${media.desktop`
     padding: 0;
-    margin-left: 80px;
+    margin-left: 90px;
     max-width: 45vw;
   `};
   ${media.desktopHD`
@@ -70,6 +70,10 @@ const InfoPlaceholder = styled.div`
  `};
 `
 
+const Section = styled.div`
+  margin-bottom: 60px;
+`
+
 export default class Event extends Component {
   render() {
     const {
@@ -96,10 +100,14 @@ export default class Event extends Component {
         </HeroImageAndTitle>
         <InfoPlaceholder>put things inside me plz</InfoPlaceholder>
         <ContentWrapper>
-          <ReactMarkdown source={eventDescription.eventDescription} />
-          <EventSchedule schedule={performances} />
-          <EventsYouMayLike eventId={id} />
+          <Section>
+            <ReactMarkdown source={eventDescription.eventDescription} />
+          </Section>
+          <Section>
+            <EventSchedule schedule={performances} />
+          </Section>
         </ContentWrapper>
+        <EventsYouMayLike eventId={id} />
       </PageWrapper>
     )
   }

--- a/src/templates/events/EventListingCard.js
+++ b/src/templates/events/EventListingCard.js
@@ -35,8 +35,10 @@ const CardDate = styled.span`
   display: block;
   color: ${props => props.theme.colors.darkGrey};
   font-size: 0.875rem;
-  font-weight: bold;
-  margin-bottom: 0.625rem;
+  line-height: 1.43;
+  font-weight: 600;
+  margin-bottom: 0.65rem;
+  font-family: Poppins, sans-serif;
 `
 
 const CardPrice = styled.div`
@@ -49,6 +51,13 @@ const CardPrice = styled.div`
   font-weight: 600;
   padding: 5px 10px;
   border-radius: 5px;
+  font-size: 1rem;
+`
+
+const CardHeading = styled.h2`
+  margin-bottom: 0;
+  line-height: 1.21;
+  color: black;
 `
 
 export const EventListingCard = props => {
@@ -64,7 +73,7 @@ export const EventListingCard = props => {
       />
       <CardBody>
         <CardDate>{formatDate(event)}</CardDate>
-        <h2>{event.name}</h2>
+        <CardHeading>{event.name}</CardHeading>
       </CardBody>
       <CardPrice>from £{event.eventPriceLow}</CardPrice>
     </Card>

--- a/src/templates/events/EventScheduleItem.js
+++ b/src/templates/events/EventScheduleItem.js
@@ -2,29 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-const fontStyles = `
-  font-size: 0.8em;
-  letter-spacing: 0.4px;
-  padding: 8px 12px
-`
-
-const ShowMore = styled.p`
-  border-bottom: 2px solid ${props => props.theme.colors.eucalyptusGreen};
-  color: ${props => props.theme.colors.indigo};
-  cursor: pointer;
-  font-size: 0.9em;
-  font-weight: 300;
-  letter-spacing: 0.4px;
-  margin: 15px auto;
-  user-select: none;
-  width: fit-content;
-`
-
-const ShowMoreWrapper = styled.div`
-  text-align: center;
-  width: 100%;
-`
-
 const Table = styled.table`
   text-align: left;
   width: 100%;
@@ -32,15 +9,16 @@ const Table = styled.table`
 `
 
 const TableHeader = styled.th`
-  ${fontStyles}
-  background: ${props => props.theme.colors.mediumGrey};
+  padding: 10px 20px;
+  font-size: 1rem;
+  background: ${props => props.theme.colors.lightGrey};
   color: ${props => props.theme.colors.indigo};
   font-family: ${props => props.theme.fonts.title};
   font-weight: 300;
 `
 
 const TableItem = styled.td`
-  ${fontStyles};
+  padding: 10px 20px;
   border-bottom: 1px solid ${props => props.theme.colors.mediumGrey};
 `
 
@@ -49,26 +27,24 @@ const TableItemTime = styled(TableItem)`
   width: 60px;
 `
 
-const EventScheduleItem = props => (
-  <div>
-    <Table>
-      <tbody>
-        <tr>
-          <TableHeader colSpan="2">{props.title}</TableHeader>
-        </tr>
-        {props.data.map(item => (
-          <tr key={item.id}>
-            <TableItemTime>{item.startTime}</TableItemTime>
-            <TableItem>{item.title}</TableItem>
+const EventScheduleItem = props =>
+  props.data.length ? (
+    <div>
+      <Table>
+        <tbody>
+          <tr>
+            <TableHeader colSpan="2">{props.title}</TableHeader>
           </tr>
-        ))}
-      </tbody>
-    </Table>
-    <ShowMoreWrapper>
-      <ShowMore>Show more</ShowMore>
-    </ShowMoreWrapper>
-  </div>
-)
+          {props.data.map(item => (
+            <tr key={item.id}>
+              <TableItemTime>{item.startTime}</TableItemTime>
+              <TableItem>{item.title}</TableItem>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  ) : null
 
 EventScheduleItem.propTypes = {
   data: PropTypes.array,

--- a/src/templates/events/EventsYouMayLike.js
+++ b/src/templates/events/EventsYouMayLike.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import moment from 'moment'
 import EventListingCard from './EventListingCard'
+import { ChevronRight } from '../../components/ChevronRight'
 import { Consumer } from '../../components/AppContext'
 import { Container, Row, Column } from '../../components/grid/grid'
 
@@ -10,8 +11,7 @@ const ViewAll = styled.a`
   color: ${props => props.theme.colors.indigo};
   display: block;
   font-family: ${props => props.theme.fonts.title};
-  font-size: 0.875rem;
-  letter-spacing: 0.1px;
+  font-size: 1rem;
   padding-top: 5px;
   text-align: right;
   text-decoration: none;
@@ -32,6 +32,11 @@ const filterEventsYouMayLike = (events, eventId) => {
   return filteredEvents.splice(0, 3)
 }
 
+const StyledContainer = styled(Container)`
+  padding-top: 60px;
+  background-color: ${props => props.theme.colors.lightGrey};
+`
+
 const EventsYouMayLike = ({ eventId }) => (
   <Consumer>
     {({ events }) => {
@@ -40,13 +45,15 @@ const EventsYouMayLike = ({ eventId }) => (
       if (eventsYouMayLike.length === 0) return null
 
       return (
-        <Container>
+        <StyledContainer>
           <Row>
             <Column width={0.7}>
-              <h2>You may also like</h2>
+              <h1>You may also like</h1>
             </Column>
             <Column width={0.3}>
-              <ViewAll href="/events">View all events {'>'}</ViewAll>
+              <ViewAll href="/events">
+                View all events <ChevronRight />
+              </ViewAll>
             </Column>
           </Row>
           <Row>
@@ -56,7 +63,7 @@ const EventsYouMayLike = ({ eventId }) => (
               </FlexColumn>
             ))}
           </Row>
-        </Container>
+        </StyledContainer>
       )
     }}
   </Consumer>


### PR DESCRIPTION
⚠️ ❗️ This is based on #46 and #45  and they should be reviewed and merged before this

Fixed these things: 

- 'You may also like' section
   - Use SVG chevron for 'view all events' cta rather than `>` character.
   - Fix font style
   
   before:
   ![image](https://user-images.githubusercontent.com/1242537/40260132-f67f1e90-5af0-11e8-9a15-fab88aceb559.png)

   after:
   ![image](https://user-images.githubusercontent.com/1242537/40259973-58e93224-5af0-11e8-86f4-d7549796ab0a.png)

- Spacing between sections in body content area of event page
   before: 
   ![image](https://user-images.githubusercontent.com/1242537/40260099-dcaceb82-5af0-11e8-85f2-d4c2a48991b8.png)

   after: 
   ![image](https://user-images.githubusercontent.com/1242537/40260081-c55ed904-5af0-11e8-8cab-101158d0acba.png)

- Font style and spacing in event card
   before:
   ![image](https://user-images.githubusercontent.com/1242537/40260207-54c2bf3e-5af1-11e8-8360-c990bb780128.png)

   after:
   ![image](https://user-images.githubusercontent.com/1242537/40260521-02223b54-5af3-11e8-8b8f-1b7c6eba1bc6.png)


- Event Schedule
   - Font style and spacing 
   - Deleted 'show more' button 
   - Don't show event schedule if there are no schedule items
   before:
   ![image](https://user-images.githubusercontent.com/1242537/40260253-875f13d4-5af1-11e8-9ea2-6a1a44b56bf1.png)

   after: 
   ![image](https://user-images.githubusercontent.com/1242537/40260238-7afa550e-5af1-11e8-9bfd-fefe28660fa0.png)

